### PR TITLE
Add fields.clicker

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,6 +11,7 @@ digistuff.ts_on_receive_fields = function (pos, formname, fields, sender)
 		return
 	end
 	local init = meta:get_int("init") == 1
+	fields.clicker               = playername
 	fields.interactingPlayerName = playername
 	if not init then
 		if fields.save then


### PR DESCRIPTION
This makes digistuff-BillyS compatible with the latest upstream digistuff by adding `event.msg.clicker`.